### PR TITLE
fix [twitter_client] Handle the situation where get_tweets_by_query()…

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -1,3 +1,4 @@
+import requests
 from flask import Flask, jsonify, request, g
 
 import twitter_client
@@ -23,7 +24,7 @@ def root_view():
 
 @app.route('/hashtags/<string:hashtag>')
 def get_by_hash_tag(hashtag):
-    limit = request.args.get('limit', DEFAULT_REQUEST_LIMIT)
+    limit = int(request.args.get('limit', DEFAULT_REQUEST_LIMIT))
 
     client = get_client()
     tweets = client.get_tweets_by_hashtag(hashtag, limit=limit)
@@ -34,7 +35,7 @@ def get_by_hash_tag(hashtag):
 
 @app.route('/users/<string:screen_name>')
 def get_by_user(screen_name):
-    limit = request.args.get('limit', DEFAULT_REQUEST_LIMIT)
+    limit = int(request.args.get('limit', DEFAULT_REQUEST_LIMIT))
 
     client = get_client()
     tweets = client.get_tweets_by_user(screen_name, limit=limit)


### PR DESCRIPTION
… tries to fetch large amounts of data which cannot be handled by single Twitter-API request. (#5)

Since Twitter-API has a MAX_LIMIT of 100 returned-tweets per request.
For fetching LIMIT > MAX_LIMIT we have to fire multiple requests and aggregate them together.

This commit add a helper function twitter_client.Client._get_all_resources() for
fetching large amounts of data which exceeds the MAX_LIMIT per Twitter-API request.

It does so by using the pagination schema described in https://developer.twitter.com/en/docs/tweets/timelines/guides/working-with-timelines

This will fix #5